### PR TITLE
Fix condition for fetching tags in CI-Dev workflow to use 'github.ref…

### DIFF
--- a/.github/workflows/CI-Dev.yml
+++ b/.github/workflows/CI-Dev.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           echo "version=v0.`expr ${{ github.run_number }} / 10`.`expr ${{ github.run_number }} % 10`" >> $GITHUB_OUTPUT
       - name: Get Tags
-        if: ${{ github.ref == 'main' }}
+        if: ${{ github.ref_name == 'main' }}
         id: tags
         run: |
           git fetch --tags


### PR DESCRIPTION
…_name'

## :memo:  Brief description

<!-- Write you description here -->

<!-- Diff summary - START -->
<!-- Diff summary - END -->


## :computer:  Commits
<!-- Diff commits - START -->
<!-- Diff commits - END -->


## :file_folder:  Modified files
<!-- Diff files - START -->
<!-- Diff files - END -->


## :warning: Additional information
* [ ] Pushed to a branch with a proper name and provided proper commit message.
* [ ] Provided a clear and concise description of what the issue is.


*Check [CONTRIBUTING.md][contributing] and [CODE_OF_CONDUCT.md][code] for more information*

[contributing]: https://github.com/devops-infra/.github/blob/master/CONTRIBUTING.md
[code]: https://github.com/devops-infra/.github/blob/master/CODE_OF_CONDUCT.md
